### PR TITLE
Update lists.html to fix typo

### DIFF
--- a/lists.html
+++ b/lists.html
@@ -95,7 +95,7 @@
 
 			<section class="container" id="lists">
 				<h5 class="title">Lists</h5>
-				<p>The List is a very versatile and common way to display items. Milligram has three types of lists: The unordered list use <code>&lt;ol&gt;</code> element will be marked with a outline circles, the ordered list use <code>&lt;ul&gt;</code> element and your items will be marked with numbers, the description list use <code>&lt;dl&gt;</code> element and your items will not be marking, only spacings.</p>
+				<p>The List is a very versatile and common way to display items. Milligram has three types of lists: The unordered list use <code>&lt;ul&gt;</code> element will be marked with a outline circles, the ordered list use <code>&lt;ol&gt;</code> element and your items will be marked with numbers, the description list use <code>&lt;dl&gt;</code> element and your items will not be marking, only spacings.</p>
 				<div class="row example">
 					<div class="column">
 						<dl>


### PR DESCRIPTION
Fix where was mentioned "ordered list use element `ul` and unordered list the `ol`", when is exactly the other way around :hear_no_evil: 