### PR TITLE
use https instead of http

### DIFF
--- a/blockquotes.html
+++ b/blockquotes.html
@@ -7,32 +7,32 @@
 		<meta name="apple-mobile-web-app-status-bar-style" content="#f4f5f6">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<meta name="author" content="http://milligram.github.io/">
+		<meta name="author" content="https://milligram.github.io/">
 		<meta name="description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
 		<meta property="og:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta property="og:image" content="http://milligram.github.io/img/thumbnail.jpg">
+		<meta property="og:image" content="https://milligram.github.io/img/thumbnail.jpg">
 		<meta property="og:locale" content="en">
 		<meta property="og:site_name" content="Milligram | A minimalist CSS framework.">
 		<meta property="og:title" content="Milligram | A minimalist CSS framework.">
 		<meta property="og:type" content="website">
-		<meta property="og:url" content="http://milligram.github.io/">
+		<meta property="og:url" content="https://milligram.github.io/">
 		<meta property="article:published_time" content="2015-12-25T01:00:00Z">
 		<meta property="article:author" content="CJ Patoilo">
 		<meta property="article:section" content="website">
 		<meta name="twitter:card" content="summary_large_image">
 		<meta name="twitter:domain" content="Milligram | A minimalist CSS framework.">
-		<meta name="twitter:url" content="http://milligram.github.io/">
-		<meta name="twitter:site" content="http://milligram.github.io/">
+		<meta name="twitter:url" content="https://milligram.github.io/">
+		<meta name="twitter:site" content="https://milligram.github.io/">
 		<meta name="twitter:creator" content="CJ Patoilo">
 		<meta name="twitter:title" content="Milligram | A minimalist CSS framework.">
 		<meta name="twitter:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta name="twitter:image:src" content="http://milligram.github.io/img/thumbnail.jpg">
+		<meta name="twitter:image:src" content="https://milligram.github.io/img/thumbnail.jpg">
 		<title>Milligram | A minimalist CSS framework.</title>
-		<link rel="canonical" href="http://milligram.github.io/">
-		<link rel="image_src" href="http://milligram.github.io/img/thumbnail.jpg">
-		<link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
+		<link rel="canonical" href="https://milligram.github.io/">
+		<link rel="image_src" href="https://milligram.github.io/img/thumbnail.jpg">
+		<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
 		<link rel="stylesheet" href="css/milligram.min.css">
 		<link rel="stylesheet" href="css/style.css">
 		<link rel="icon" href="img/favicon.png">
@@ -150,7 +150,7 @@
 
 		</main>
 
-		<script src="http://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
 		<script src="js/script.js"></script>
 
 	</body>

--- a/browser-support.html
+++ b/browser-support.html
@@ -7,32 +7,32 @@
 		<meta name="apple-mobile-web-app-status-bar-style" content="#f4f5f6">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<meta name="author" content="http://milligram.github.io/">
+		<meta name="author" content="https://milligram.github.io/">
 		<meta name="description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
 		<meta property="og:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta property="og:image" content="http://milligram.github.io/img/thumbnail.jpg">
+		<meta property="og:image" content="https://milligram.github.io/img/thumbnail.jpg">
 		<meta property="og:locale" content="en">
 		<meta property="og:site_name" content="Milligram | A minimalist CSS framework.">
 		<meta property="og:title" content="Milligram | A minimalist CSS framework.">
 		<meta property="og:type" content="website">
-		<meta property="og:url" content="http://milligram.github.io/">
+		<meta property="og:url" content="https://milligram.github.io/">
 		<meta property="article:published_time" content="2015-12-25T01:00:00Z">
 		<meta property="article:author" content="CJ Patoilo">
 		<meta property="article:section" content="website">
 		<meta name="twitter:card" content="summary_large_image">
 		<meta name="twitter:domain" content="Milligram | A minimalist CSS framework.">
-		<meta name="twitter:url" content="http://milligram.github.io/">
-		<meta name="twitter:site" content="http://milligram.github.io/">
+		<meta name="twitter:url" content="https://milligram.github.io/">
+		<meta name="twitter:site" content="https://milligram.github.io/">
 		<meta name="twitter:creator" content="CJ Patoilo">
 		<meta name="twitter:title" content="Milligram | A minimalist CSS framework.">
 		<meta name="twitter:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta name="twitter:image:src" content="http://milligram.github.io/img/thumbnail.jpg">
+		<meta name="twitter:image:src" content="https://milligram.github.io/img/thumbnail.jpg">
 		<title>Milligram | A minimalist CSS framework.</title>
-		<link rel="canonical" href="http://milligram.github.io/">
-		<link rel="image_src" href="http://milligram.github.io/img/thumbnail.jpg">
-		<link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
+		<link rel="canonical" href="https://milligram.github.io/">
+		<link rel="image_src" href="https://milligram.github.io/img/thumbnail.jpg">
+		<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
 		<link rel="stylesheet" href="css/milligram.min.css">
 		<link rel="stylesheet" href="css/style.css">
 		<link rel="icon" href="img/favicon.png">
@@ -149,7 +149,7 @@
 
 		</main>
 
-		<script src="http://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
 		<script src="js/script.js"></script>
 
 	</body>

--- a/buttons.html
+++ b/buttons.html
@@ -7,32 +7,32 @@
 		<meta name="apple-mobile-web-app-status-bar-style" content="#f4f5f6">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<meta name="author" content="http://milligram.github.io/">
+		<meta name="author" content="https://milligram.github.io/">
 		<meta name="description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
 		<meta property="og:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta property="og:image" content="http://milligram.github.io/img/thumbnail.jpg">
+		<meta property="og:image" content="https://milligram.github.io/img/thumbnail.jpg">
 		<meta property="og:locale" content="en">
 		<meta property="og:site_name" content="Milligram | A minimalist CSS framework.">
 		<meta property="og:title" content="Milligram | A minimalist CSS framework.">
 		<meta property="og:type" content="website">
-		<meta property="og:url" content="http://milligram.github.io/">
+		<meta property="og:url" content="https://milligram.github.io/">
 		<meta property="article:published_time" content="2015-12-25T01:00:00Z">
 		<meta property="article:author" content="CJ Patoilo">
 		<meta property="article:section" content="website">
 		<meta name="twitter:card" content="summary_large_image">
 		<meta name="twitter:domain" content="Milligram | A minimalist CSS framework.">
-		<meta name="twitter:url" content="http://milligram.github.io/">
-		<meta name="twitter:site" content="http://milligram.github.io/">
+		<meta name="twitter:url" content="https://milligram.github.io/">
+		<meta name="twitter:site" content="https://milligram.github.io/">
 		<meta name="twitter:creator" content="CJ Patoilo">
 		<meta name="twitter:title" content="Milligram | A minimalist CSS framework.">
 		<meta name="twitter:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta name="twitter:image:src" content="http://milligram.github.io/img/thumbnail.jpg">
+		<meta name="twitter:image:src" content="https://milligram.github.io/img/thumbnail.jpg">
 		<title>Milligram | A minimalist CSS framework.</title>
-		<link rel="canonical" href="http://milligram.github.io/">
-		<link rel="image_src" href="http://milligram.github.io/img/thumbnail.jpg">
-		<link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
+		<link rel="canonical" href="https://milligram.github.io/">
+		<link rel="image_src" href="https://milligram.github.io/img/thumbnail.jpg">
+		<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
 		<link rel="stylesheet" href="css/milligram.min.css">
 		<link rel="stylesheet" href="css/style.css">
 		<link rel="icon" href="img/favicon.png">
@@ -157,7 +157,7 @@
 
 		</main>
 
-		<script src="http://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
 		<script src="js/script.js"></script>
 
 	</body>

--- a/codes.html
+++ b/codes.html
@@ -7,32 +7,32 @@
 		<meta name="apple-mobile-web-app-status-bar-style" content="#f4f5f6">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<meta name="author" content="http://milligram.github.io/">
+		<meta name="author" content="https://milligram.github.io/">
 		<meta name="description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
 		<meta property="og:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta property="og:image" content="http://milligram.github.io/img/thumbnail.jpg">
+		<meta property="og:image" content="https://milligram.github.io/img/thumbnail.jpg">
 		<meta property="og:locale" content="en">
 		<meta property="og:site_name" content="Milligram | A minimalist CSS framework.">
 		<meta property="og:title" content="Milligram | A minimalist CSS framework.">
 		<meta property="og:type" content="website">
-		<meta property="og:url" content="http://milligram.github.io/">
+		<meta property="og:url" content="https://milligram.github.io/">
 		<meta property="article:published_time" content="2015-12-25T01:00:00Z">
 		<meta property="article:author" content="CJ Patoilo">
 		<meta property="article:section" content="website">
 		<meta name="twitter:card" content="summary_large_image">
 		<meta name="twitter:domain" content="Milligram | A minimalist CSS framework.">
-		<meta name="twitter:url" content="http://milligram.github.io/">
-		<meta name="twitter:site" content="http://milligram.github.io/">
+		<meta name="twitter:url" content="https://milligram.github.io/">
+		<meta name="twitter:site" content="https://milligram.github.io/">
 		<meta name="twitter:creator" content="CJ Patoilo">
 		<meta name="twitter:title" content="Milligram | A minimalist CSS framework.">
 		<meta name="twitter:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta name="twitter:image:src" content="http://milligram.github.io/img/thumbnail.jpg">
+		<meta name="twitter:image:src" content="https://milligram.github.io/img/thumbnail.jpg">
 		<title>Milligram | A minimalist CSS framework.</title>
-		<link rel="canonical" href="http://milligram.github.io/">
-		<link rel="image_src" href="http://milligram.github.io/img/thumbnail.jpg">
-		<link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
+		<link rel="canonical" href="https://milligram.github.io/">
+		<link rel="image_src" href="https://milligram.github.io/img/thumbnail.jpg">
+		<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
 		<link rel="stylesheet" href="css/milligram.min.css">
 		<link rel="stylesheet" href="css/style.css">
 		<link rel="icon" href="img/favicon.png">
@@ -153,7 +153,7 @@
 
 		</main>
 
-		<script src="http://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
 		<script src="js/script.js"></script>
 
 	</body>

--- a/forms.html
+++ b/forms.html
@@ -7,32 +7,32 @@
 		<meta name="apple-mobile-web-app-status-bar-style" content="#f4f5f6">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<meta name="author" content="http://milligram.github.io/">
+		<meta name="author" content="https://milligram.github.io/">
 		<meta name="description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
 		<meta property="og:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta property="og:image" content="http://milligram.github.io/img/thumbnail.jpg">
+		<meta property="og:image" content="https://milligram.github.io/img/thumbnail.jpg">
 		<meta property="og:locale" content="en">
 		<meta property="og:site_name" content="Milligram | A minimalist CSS framework.">
 		<meta property="og:title" content="Milligram | A minimalist CSS framework.">
 		<meta property="og:type" content="website">
-		<meta property="og:url" content="http://milligram.github.io/">
+		<meta property="og:url" content="https://milligram.github.io/">
 		<meta property="article:published_time" content="2015-12-25T01:00:00Z">
 		<meta property="article:author" content="CJ Patoilo">
 		<meta property="article:section" content="website">
 		<meta name="twitter:card" content="summary_large_image">
 		<meta name="twitter:domain" content="Milligram | A minimalist CSS framework.">
-		<meta name="twitter:url" content="http://milligram.github.io/">
-		<meta name="twitter:site" content="http://milligram.github.io/">
+		<meta name="twitter:url" content="https://milligram.github.io/">
+		<meta name="twitter:site" content="https://milligram.github.io/">
 		<meta name="twitter:creator" content="CJ Patoilo">
 		<meta name="twitter:title" content="Milligram | A minimalist CSS framework.">
 		<meta name="twitter:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta name="twitter:image:src" content="http://milligram.github.io/img/thumbnail.jpg">
+		<meta name="twitter:image:src" content="https://milligram.github.io/img/thumbnail.jpg">
 		<title>Milligram | A minimalist CSS framework.</title>
-		<link rel="canonical" href="http://milligram.github.io/">
-		<link rel="image_src" href="http://milligram.github.io/img/thumbnail.jpg">
-		<link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
+		<link rel="canonical" href="https://milligram.github.io/">
+		<link rel="image_src" href="https://milligram.github.io/img/thumbnail.jpg">
+		<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
 		<link rel="stylesheet" href="css/milligram.min.css">
 		<link rel="stylesheet" href="css/style.css">
 		<link rel="icon" href="img/favicon.png">
@@ -172,7 +172,7 @@
 
 		</main>
 
-		<script src="http://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
 		<script src="js/script.js"></script>
 
 	</body>

--- a/getting-started.html
+++ b/getting-started.html
@@ -7,32 +7,32 @@
 		<meta name="apple-mobile-web-app-status-bar-style" content="#f4f5f6">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<meta name="author" content="http://milligram.github.io/">
+		<meta name="author" content="https://milligram.github.io/">
 		<meta name="description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
 		<meta property="og:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta property="og:image" content="http://milligram.github.io/img/thumbnail.jpg">
+		<meta property="og:image" content="https://milligram.github.io/img/thumbnail.jpg">
 		<meta property="og:locale" content="en">
 		<meta property="og:site_name" content="Milligram | A minimalist CSS framework.">
 		<meta property="og:title" content="Milligram | A minimalist CSS framework.">
 		<meta property="og:type" content="website">
-		<meta property="og:url" content="http://milligram.github.io/">
+		<meta property="og:url" content="https://milligram.github.io/">
 		<meta property="article:published_time" content="2015-12-25T01:00:00Z">
 		<meta property="article:author" content="CJ Patoilo">
 		<meta property="article:section" content="website">
 		<meta name="twitter:card" content="summary_large_image">
 		<meta name="twitter:domain" content="Milligram | A minimalist CSS framework.">
-		<meta name="twitter:url" content="http://milligram.github.io/">
-		<meta name="twitter:site" content="http://milligram.github.io/">
+		<meta name="twitter:url" content="https://milligram.github.io/">
+		<meta name="twitter:site" content="https://milligram.github.io/">
 		<meta name="twitter:creator" content="CJ Patoilo">
 		<meta name="twitter:title" content="Milligram | A minimalist CSS framework.">
 		<meta name="twitter:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta name="twitter:image:src" content="http://milligram.github.io/img/thumbnail.jpg">
+		<meta name="twitter:image:src" content="https://milligram.github.io/img/thumbnail.jpg">
 		<title>Milligram | A minimalist CSS framework.</title>
-		<link rel="canonical" href="http://milligram.github.io/">
-		<link rel="image_src" href="http://milligram.github.io/img/thumbnail.jpg">
-		<link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
+		<link rel="canonical" href="https://milligram.github.io/">
+		<link rel="image_src" href="https://milligram.github.io/img/thumbnail.jpg">
+		<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
 		<link rel="stylesheet" href="css/milligram.min.css">
 		<link rel="stylesheet" href="css/style.css">
 		<link rel="icon" href="img/favicon.png">
@@ -174,7 +174,7 @@
 
 		</main>
 
-		<script src="http://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
 		<script src="js/script.js"></script>
 
 	</body>

--- a/grids.html
+++ b/grids.html
@@ -7,32 +7,32 @@
 		<meta name="apple-mobile-web-app-status-bar-style" content="#f4f5f6">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<meta name="author" content="http://milligram.github.io/">
+		<meta name="author" content="https://milligram.github.io/">
 		<meta name="description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
 		<meta property="og:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta property="og:image" content="http://milligram.github.io/img/thumbnail.jpg">
+		<meta property="og:image" content="https://milligram.github.io/img/thumbnail.jpg">
 		<meta property="og:locale" content="en">
 		<meta property="og:site_name" content="Milligram | A minimalist CSS framework.">
 		<meta property="og:title" content="Milligram | A minimalist CSS framework.">
 		<meta property="og:type" content="website">
-		<meta property="og:url" content="http://milligram.github.io/">
+		<meta property="og:url" content="https://milligram.github.io/">
 		<meta property="article:published_time" content="2015-12-25T01:00:00Z">
 		<meta property="article:author" content="CJ Patoilo">
 		<meta property="article:section" content="website">
 		<meta name="twitter:card" content="summary_large_image">
 		<meta name="twitter:domain" content="Milligram | A minimalist CSS framework.">
-		<meta name="twitter:url" content="http://milligram.github.io/">
-		<meta name="twitter:site" content="http://milligram.github.io/">
+		<meta name="twitter:url" content="https://milligram.github.io/">
+		<meta name="twitter:site" content="https://milligram.github.io/">
 		<meta name="twitter:creator" content="CJ Patoilo">
 		<meta name="twitter:title" content="Milligram | A minimalist CSS framework.">
 		<meta name="twitter:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta name="twitter:image:src" content="http://milligram.github.io/img/thumbnail.jpg">
+		<meta name="twitter:image:src" content="https://milligram.github.io/img/thumbnail.jpg">
 		<title>Milligram | A minimalist CSS framework.</title>
-		<link rel="canonical" href="http://milligram.github.io/">
-		<link rel="image_src" href="http://milligram.github.io/img/thumbnail.jpg">
-		<link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
+		<link rel="canonical" href="https://milligram.github.io/">
+		<link rel="image_src" href="https://milligram.github.io/img/thumbnail.jpg">
+		<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
 		<link rel="stylesheet" href="css/milligram.min.css">
 		<link rel="stylesheet" href="css/style.css">
 		<link rel="icon" href="img/favicon.png">
@@ -174,7 +174,7 @@
 
 		</main>
 
-		<script src="http://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
 		<script src="js/script.js"></script>
 
 	</body>

--- a/index.html
+++ b/index.html
@@ -7,32 +7,32 @@
 		<meta name="apple-mobile-web-app-status-bar-style" content="#f4f5f6">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<meta name="author" content="http://milligram.github.io/">
+		<meta name="author" content="https://milligram.github.io/">
 		<meta name="description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
 		<meta property="og:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta property="og:image" content="http://milligram.github.io/img/thumbnail.jpg">
+		<meta property="og:image" content="https://milligram.github.io/img/thumbnail.jpg">
 		<meta property="og:locale" content="en">
 		<meta property="og:site_name" content="Milligram | A minimalist CSS framework.">
 		<meta property="og:title" content="Milligram | A minimalist CSS framework.">
 		<meta property="og:type" content="website">
-		<meta property="og:url" content="http://milligram.github.io/">
+		<meta property="og:url" content="https://milligram.github.io/">
 		<meta property="article:published_time" content="2015-12-25T01:00:00Z">
 		<meta property="article:author" content="CJ Patoilo">
 		<meta property="article:section" content="website">
 		<meta name="twitter:card" content="summary_large_image">
 		<meta name="twitter:domain" content="Milligram | A minimalist CSS framework.">
-		<meta name="twitter:url" content="http://milligram.github.io/">
-		<meta name="twitter:site" content="http://milligram.github.io/">
+		<meta name="twitter:url" content="https://milligram.github.io/">
+		<meta name="twitter:site" content="https://milligram.github.io/">
 		<meta name="twitter:creator" content="CJ Patoilo">
 		<meta name="twitter:title" content="Milligram | A minimalist CSS framework.">
 		<meta name="twitter:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta name="twitter:image:src" content="http://milligram.github.io/img/thumbnail.jpg">
+		<meta name="twitter:image:src" content="https://milligram.github.io/img/thumbnail.jpg">
 		<title>Milligram | A minimalist CSS framework.</title>
-		<link rel="canonical" href="http://milligram.github.io/">
-		<link rel="image_src" href="http://milligram.github.io/img/thumbnail.jpg">
-		<link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
+		<link rel="canonical" href="https://milligram.github.io/">
+		<link rel="image_src" href="https://milligram.github.io/img/thumbnail.jpg">
+		<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
 		<link rel="stylesheet" href="css/milligram.min.css">
 		<link rel="stylesheet" href="css/style.css">
 		<link rel="icon" href="img/favicon.png">
@@ -577,7 +577,7 @@
 
 		</main>
 
-		<script src="http://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
 		<script src="js/script.js"></script>
 
 	</body>

--- a/lists.html
+++ b/lists.html
@@ -7,32 +7,32 @@
 		<meta name="apple-mobile-web-app-status-bar-style" content="#f4f5f6">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<meta name="author" content="http://milligram.github.io/">
+		<meta name="author" content="https://milligram.github.io/">
 		<meta name="description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
 		<meta property="og:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta property="og:image" content="http://milligram.github.io/img/thumbnail.jpg">
+		<meta property="og:image" content="https://milligram.github.io/img/thumbnail.jpg">
 		<meta property="og:locale" content="en">
 		<meta property="og:site_name" content="Milligram | A minimalist CSS framework.">
 		<meta property="og:title" content="Milligram | A minimalist CSS framework.">
 		<meta property="og:type" content="website">
-		<meta property="og:url" content="http://milligram.github.io/">
+		<meta property="og:url" content="https://milligram.github.io/">
 		<meta property="article:published_time" content="2015-12-25T01:00:00Z">
 		<meta property="article:author" content="CJ Patoilo">
 		<meta property="article:section" content="website">
 		<meta name="twitter:card" content="summary_large_image">
 		<meta name="twitter:domain" content="Milligram | A minimalist CSS framework.">
-		<meta name="twitter:url" content="http://milligram.github.io/">
-		<meta name="twitter:site" content="http://milligram.github.io/">
+		<meta name="twitter:url" content="https://milligram.github.io/">
+		<meta name="twitter:site" content="https://milligram.github.io/">
 		<meta name="twitter:creator" content="CJ Patoilo">
 		<meta name="twitter:title" content="Milligram | A minimalist CSS framework.">
 		<meta name="twitter:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta name="twitter:image:src" content="http://milligram.github.io/img/thumbnail.jpg">
+		<meta name="twitter:image:src" content="https://milligram.github.io/img/thumbnail.jpg">
 		<title>Milligram | A minimalist CSS framework.</title>
-		<link rel="canonical" href="http://milligram.github.io/">
-		<link rel="image_src" href="http://milligram.github.io/img/thumbnail.jpg">
-		<link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
+		<link rel="canonical" href="https://milligram.github.io/">
+		<link rel="image_src" href="https://milligram.github.io/img/thumbnail.jpg">
+		<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
 		<link rel="stylesheet" href="css/milligram.min.css">
 		<link rel="stylesheet" href="css/style.css">
 		<link rel="icon" href="img/favicon.png">
@@ -181,7 +181,7 @@
 
 		</main>
 
-		<script src="http://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
 		<script src="js/script.js"></script>
 
 	</body>

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# [Milligram](http://milligram.github.io)
+# [Milligram](https://milligram.github.io)
 
 | A minimalist CSS framework.
 
@@ -31,19 +31,19 @@ $ npm install milligram
 
 ## Table of Contents
 
-- [Getting Started](http://milligram.github.io/#getting-started)
-- [Typography](http://milligram.github.io/#typography)
-- [Blockquotes](http://milligram.github.io/#blockquotes)
-- [Buttons](http://milligram.github.io/#buttons)
-- [Lists](http://milligram.github.io/#lists)
-- [Forms](http://milligram.github.io/#forms)
-- [Tables](http://milligram.github.io/#tables)
-- [Grids](http://milligram.github.io/#grids)
-- [Codes](http://milligram.github.io/#codes)
-- [Utilities](http://milligram.github.io/#utilities)
-- [Tips](http://milligram.github.io/#tips)
-- [Browser Support](http://milligram.github.io/#browser-support)
-- [Examples](http://milligram.github.io/#examples)
+- [Getting Started](https://milligram.github.io/#getting-started)
+- [Typography](https://milligram.github.io/#typography)
+- [Blockquotes](https://milligram.github.io/#blockquotes)
+- [Buttons](https://milligram.github.io/#buttons)
+- [Lists](https://milligram.github.io/#lists)
+- [Forms](https://milligram.github.io/#forms)
+- [Tables](https://milligram.github.io/#tables)
+- [Grids](https://milligram.github.io/#grids)
+- [Codes](https://milligram.github.io/#codes)
+- [Utilities](https://milligram.github.io/#utilities)
+- [Tips](https://milligram.github.io/#tips)
+- [Browser Support](https://milligram.github.io/#browser-support)
+- [Examples](https://milligram.github.io/#examples)
 
 
 ## Contributing

--- a/tables.html
+++ b/tables.html
@@ -1,128 +1,128 @@
 <!doctype html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8">
-		<meta name="robots" content="index, follow">
-		<meta name="theme-color" content="#f4f5f6">
-		<meta name="apple-mobile-web-app-status-bar-style" content="#f4f5f6">
-		<meta name="apple-mobile-web-app-capable" content="yes">
-		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<meta name="author" content="http://milligram.github.io/">
-		<meta name="description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta property="og:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta property="og:image" content="http://milligram.github.io/img/thumbnail.jpg">
-		<meta property="og:locale" content="en">
-		<meta property="og:site_name" content="Milligram | A minimalist CSS framework.">
-		<meta property="og:title" content="Milligram | A minimalist CSS framework.">
-		<meta property="og:type" content="website">
-		<meta property="og:url" content="http://milligram.github.io/">
-		<meta property="article:published_time" content="2015-12-25T01:00:00Z">
-		<meta property="article:author" content="CJ Patoilo">
-		<meta property="article:section" content="website">
-		<meta name="twitter:card" content="summary_large_image">
-		<meta name="twitter:domain" content="Milligram | A minimalist CSS framework.">
-		<meta name="twitter:url" content="http://milligram.github.io/">
-		<meta name="twitter:site" content="http://milligram.github.io/">
-		<meta name="twitter:creator" content="CJ Patoilo">
-		<meta name="twitter:title" content="Milligram | A minimalist CSS framework.">
-		<meta name="twitter:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta name="twitter:image:src" content="http://milligram.github.io/img/thumbnail.jpg">
-		<title>Milligram | A minimalist CSS framework.</title>
-		<link rel="canonical" href="http://milligram.github.io/">
-		<link rel="image_src" href="http://milligram.github.io/img/thumbnail.jpg">
-		<link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
-		<link rel="stylesheet" href="css/milligram.min.css">
-		<link rel="stylesheet" href="css/style.css">
-		<link rel="icon" href="img/favicon.png">
-	</head>
-	<body>
+    <head>
+        <meta charset="utf-8">
+        <meta name="robots" content="index, follow">
+        <meta name="theme-color" content="#f4f5f6">
+        <meta name="apple-mobile-web-app-status-bar-style" content="#f4f5f6">
+        <meta name="apple-mobile-web-app-capable" content="yes">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="author" content="https://milligram.github.io/">
+        <meta name="description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
+        <meta property="og:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
+        <meta property="og:image" content="https://milligram.github.io/img/thumbnail.jpg">
+        <meta property="og:locale" content="en">
+        <meta property="og:site_name" content="Milligram | A minimalist CSS framework.">
+        <meta property="og:title" content="Milligram | A minimalist CSS framework.">
+        <meta property="og:type" content="website">
+        <meta property="og:url" content="https://milligram.github.io/">
+        <meta property="article:published_time" content="2015-12-25T01:00:00Z">
+        <meta property="article:author" content="CJ Patoilo">
+        <meta property="article:section" content="website">
+        <meta name="twitter:card" content="summary_large_image">
+        <meta name="twitter:domain" content="Milligram | A minimalist CSS framework.">
+        <meta name="twitter:url" content="https://milligram.github.io/">
+        <meta name="twitter:site" content="https://milligram.github.io/">
+        <meta name="twitter:creator" content="CJ Patoilo">
+        <meta name="twitter:title" content="Milligram | A minimalist CSS framework.">
+        <meta name="twitter:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
+        <meta name="twitter:image:src" content="https://milligram.github.io/img/thumbnail.jpg">
+        <title>Milligram | A minimalist CSS framework.</title>
+        <link rel="canonical" href="https://milligram.github.io/">
+        <link rel="image_src" href="https://milligram.github.io/img/thumbnail.jpg">
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
+        <link rel="stylesheet" href="css/milligram.min.css">
+        <link rel="stylesheet" href="css/style.css">
+        <link rel="icon" href="img/favicon.png">
+    </head>
+    <body>
 
-		<main class="wrapper">
+        <main class="wrapper">
 
-			<nav class="navigation">
-				<section class="container">
+            <nav class="navigation">
+                <section class="container">
 
-					<a class="navigation-title" href="index.html">
-						<img class="img" src="img/logo.svg" height="30" alt="Milligram" title="Milligram">
-						<h1 class="title">Milligram</h1>
-					</a>
+                    <a class="navigation-title" href="index.html">
+                        <img class="img" src="img/logo.svg" height="30" alt="Milligram" title="Milligram">
+                        <h1 class="title">Milligram</h1>
+                    </a>
 
-					<ul class="navigation-list float-right">
-						<li class="navigation-item">
-							<a class="navigation-link" href="#popover-grid" data-popover>Docs</a>
-							<div class="popover" id="popover-grid">
-								<ul class="popover-list">
-									<li class="popover-item"><a class="popover-link" href="index.html#getting-started" title="Getting Started">Getting Started</a></li>
-									<li class="popover-item"><a class="popover-link" href="index.html#typography" title="Typography">Typography</a></li>
-									<li class="popover-item"><a class="popover-link" href="index.html#blockquotes" title="Blockquotes">Blockquotes</a></li>
-									<li class="popover-item"><a class="popover-link" href="index.html#buttons" title="Buttons">Buttons</a></li>
-									<li class="popover-item"><a class="popover-link" href="index.html#lists" title="Lists">Lists</a></li>
-									<li class="popover-item"><a class="popover-link" href="index.html#forms" title="Forms">Forms</a></li>
-									<li class="popover-item"><a class="popover-link" href="index.html#tables" title="Tables">Tables</a></li>
-									<li class="popover-item"><a class="popover-link" href="index.html#grids" title="Grids">Grids</a></li>
-									<li class="popover-item"><a class="popover-link" href="index.html#codes" title="Codes">Codes</a></li>
-									<li class="popover-item"><a class="popover-link" href="index.html#utilities" title="Utilities">Utilities</a></li>
-									<li class="popover-item"><a class="popover-link" href="index.html#tips" title="Tips">Tips</a></li>
-									<li class="popover-item"><a class="popover-link" href="index.html#browser-support" title="Browser Support">Browser Support</a></li>
-									<li class="popover-item"><a class="popover-link" href="index.html#examples" title="Examples">Examples</a></li>
-									<li class="popover-item"><a class="popover-link" href="index.html#contributing" title="Contributing">Contributing</a></li>
-								</ul>
-							</div>
-						</li>
-						<li class="navigation-item">
-							<a class="navigation-link" href="#popover-support" data-popover>Support</a>
-							<div class="popover" id="popover-support">
-								<ul class="popover-list">
-									<li class="popover-item"><a class="popover-link" target="blank" href="https://github.com/milligram/milligram" title="On Github">On Github</a></li>
-									<li class="popover-item"><a class="popover-link" target="blank" href="https://github.com/milligram/milligram/issues/new" title="Need help?">Need help?</a></li>
-									<li class="popover-item"><a class="popover-link" target="blank" href="https://github.com/milligram/milligram#license" title="License">License</a></li>
-									<li class="popover-item"><a class="popover-link" target="blank" href="https://github.com/milligram/milligram/releases" title="Versions">Versions</a></li>
-								</ul>
-							</div>
-						</li>
-					</ul>
-					<a class="hidden-xs github-corner" href="https://github.com/milligram/milligram" title="Milligram on Github" target="blank">
-						<svg width="80" height="80" viewBox="0 0 250 250" class="github-corner">
-							<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
-							<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
-							<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
-						</svg>
-					</a>
-				</section>
-			</nav>
+                    <ul class="navigation-list float-right">
+                        <li class="navigation-item">
+                            <a class="navigation-link" href="#popover-grid" data-popover>Docs</a>
+                            <div class="popover" id="popover-grid">
+                                <ul class="popover-list">
+                                    <li class="popover-item"><a class="popover-link" href="index.html#getting-started" title="Getting Started">Getting Started</a></li>
+                                    <li class="popover-item"><a class="popover-link" href="index.html#typography" title="Typography">Typography</a></li>
+                                    <li class="popover-item"><a class="popover-link" href="index.html#blockquotes" title="Blockquotes">Blockquotes</a></li>
+                                    <li class="popover-item"><a class="popover-link" href="index.html#buttons" title="Buttons">Buttons</a></li>
+                                    <li class="popover-item"><a class="popover-link" href="index.html#lists" title="Lists">Lists</a></li>
+                                    <li class="popover-item"><a class="popover-link" href="index.html#forms" title="Forms">Forms</a></li>
+                                    <li class="popover-item"><a class="popover-link" href="index.html#tables" title="Tables">Tables</a></li>
+                                    <li class="popover-item"><a class="popover-link" href="index.html#grids" title="Grids">Grids</a></li>
+                                    <li class="popover-item"><a class="popover-link" href="index.html#codes" title="Codes">Codes</a></li>
+                                    <li class="popover-item"><a class="popover-link" href="index.html#utilities" title="Utilities">Utilities</a></li>
+                                    <li class="popover-item"><a class="popover-link" href="index.html#tips" title="Tips">Tips</a></li>
+                                    <li class="popover-item"><a class="popover-link" href="index.html#browser-support" title="Browser Support">Browser Support</a></li>
+                                    <li class="popover-item"><a class="popover-link" href="index.html#examples" title="Examples">Examples</a></li>
+                                    <li class="popover-item"><a class="popover-link" href="index.html#contributing" title="Contributing">Contributing</a></li>
+                                </ul>
+                            </div>
+                        </li>
+                        <li class="navigation-item">
+                            <a class="navigation-link" href="#popover-support" data-popover>Support</a>
+                            <div class="popover" id="popover-support">
+                                <ul class="popover-list">
+                                    <li class="popover-item"><a class="popover-link" target="blank" href="https://github.com/milligram/milligram" title="On Github">On Github</a></li>
+                                    <li class="popover-item"><a class="popover-link" target="blank" href="https://github.com/milligram/milligram/issues/new" title="Need help?">Need help?</a></li>
+                                    <li class="popover-item"><a class="popover-link" target="blank" href="https://github.com/milligram/milligram#license" title="License">License</a></li>
+                                    <li class="popover-item"><a class="popover-link" target="blank" href="https://github.com/milligram/milligram/releases" title="Versions">Versions</a></li>
+                                </ul>
+                            </div>
+                        </li>
+                    </ul>
+                    <a class="hidden-xs github-corner" href="https://github.com/milligram/milligram" title="Milligram on Github" target="blank">
+                        <svg width="80" height="80" viewBox="0 0 250 250" class="github-corner">
+                            <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+                            <path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+                            <path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+                        </svg>
+                    </a>
+                </section>
+            </nav>
 
-			<section class="container" id="tables">
-				<h5 class="title">Tables</h5>
-				<p>The Table element represents data in two dimensions or more. We encourage the use of proper formatting with <code>&lt;thead&gt;</code> and <code>&lt;tbody&gt;</code> to create a <code>&lt;table&gt;</code>. The code becomes cleaner without disturbing understanding.</p>
-				<div class="example">
-					<table>
-						<thead>
-							<tr>
-								<th>Name</th>
-								<th>Age</th>
-								<th>Height</th>
-								<th>Location</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr>
-								<td>Stephen Curry</td>
-								<td>27</td>
-								<td>1,91</td>
-								<td>Akron, OH</td>
-							</tr>
-							<tr>
-								<td>Klay Thompson</td>
-								<td>25</td>
-								<td>2,01</td>
-								<td>Los Angeles, CA</td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-				<pre class="code prettyprint"><code class="code-content"><table>
+            <section class="container" id="tables">
+                <h5 class="title">Tables</h5>
+                <p>The Table element represents data in two dimensions or more. We encourage the use of proper formatting with <code>&lt;thead&gt;</code> and <code>&lt;tbody&gt;</code> to create a <code>&lt;table&gt;</code>. The code becomes cleaner without disturbing understanding.</p>
+                <div class="example">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Name</th>
+                                <th>Age</th>
+                                <th>Height</th>
+                                <th>Location</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>Stephen Curry</td>
+                                <td>27</td>
+                                <td>1,91</td>
+                                <td>Akron, OH</td>
+                            </tr>
+                            <tr>
+                                <td>Klay Thompson</td>
+                                <td>25</td>
+                                <td>2,01</td>
+                                <td>Los Angeles, CA</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <pre class="code prettyprint"><code class="code-content"><table>
   <thead>
     <tr>
       <th>Name</th>
@@ -148,54 +148,53 @@
 </table>
 
 <!-- Prior to the creation of CSS, HTML <table> elements were often used as a method for page layout. This usage has been discouraged since HTML4, and the <table> element should not be used for layout purposes. --></code></pre>
-			</section>
+            </section>
 
-			<section class="container" id="examples">
-				<h5 class="title">Examples</h5>
-				<p>You can view more examples of using Milligram.</p>
-				<p>
-					<ul>
-						<li><a href="getting-started.html" title="Getting Started">Getting Started</a></li>
-						<li><a href="typography.html" title="Typography">Typography</a></li>
-						<li><a href="blockquotes.html" title="Blockquotes">Blockquotes</a></li>
-						<li><a href="buttons.html" title="Buttons">Buttons</a></li>
-						<li><a href="lists.html" title="Lists">Lists</a></li>
-						<li><a href="forms.html" title="Forms">Forms</a></li>
-						<li><a href="tables.html" title="Tables">Tables</a></li>
-						<li><a href="grids.html" title="Grids">Grids</a></li>
-						<li><a href="codes.html" title="Codes">Codes</a></li>
-						<li><a href="utilities.html" title="Utilities">Utilities</a></li>
-						<li><a href="tips.html" title="Tips">Tips</a></li>
-						<li><a href="browser-support.html" title="Browser Support">Browser Support</a></li>
-					</ul>
-				</p>
-			</section>
+            <section class="container" id="examples">
+                <h5 class="title">Examples</h5>
+                <p>You can view more examples of using Milligram.</p>
+                <p>
+                    <ul>
+                        <li><a href="getting-started.html" title="Getting Started">Getting Started</a></li>
+                        <li><a href="typography.html" title="Typography">Typography</a></li>
+                        <li><a href="blockquotes.html" title="Blockquotes">Blockquotes</a></li>
+                        <li><a href="buttons.html" title="Buttons">Buttons</a></li>
+                        <li><a href="lists.html" title="Lists">Lists</a></li>
+                        <li><a href="forms.html" title="Forms">Forms</a></li>
+                        <li><a href="tables.html" title="Tables">Tables</a></li>
+                        <li><a href="grids.html" title="Grids">Grids</a></li>
+                        <li><a href="codes.html" title="Codes">Codes</a></li>
+                        <li><a href="utilities.html" title="Utilities">Utilities</a></li>
+                        <li><a href="tips.html" title="Tips">Tips</a></li>
+                        <li><a href="browser-support.html" title="Browser Support">Browser Support</a></li>
+                    </ul>
+                </p>
+            </section>
 
-			<section class="container" id="contributing">
-				<h5 class="title">Contributing</h5>
-				<p> Help improve these docs. Open an <a target="blank" href="https://github.com/milligram/milligram/issues/new" title="Issue">issue</a> or submit a pull request.</p>
-				<p>
-					<ol>
-						<li>Navigate to the main page of the repository</li>
-						<li><a target="blank" href="https://github.com/milligram/milligram#fork-destination-box" title="Fork it!">Fork it!</a></li>
-						<li>Create your feature branch: git checkout -b my-new-feature</li>
-						<li>Commit your changes: git commit -m 'Add some feature'</li>
-						<li>Push to the branch: git push origin my-new-feature</li>
-						<li>Submit a pull request =D</li>
-					</ol>
-				</p>
-			</section>
+            <section class="container" id="contributing">
+                <h5 class="title">Contributing</h5>
+                <p> Help improve these docs. Open an <a target="blank" href="https://github.com/milligram/milligram/issues/new" title="Issue">issue</a> or submit a pull request.</p>
+                <p>
+                    <ol>
+                        <li>Navigate to the main page of the repository</li>
+                        <li><a target="blank" href="https://github.com/milligram/milligram#fork-destination-box" title="Fork it!">Fork it!</a></li>
+                        <li>Create your feature branch: git checkout -b my-new-feature</li>
+                        <li>Commit your changes: git commit -m 'Add some feature'</li>
+                        <li>Push to the branch: git push origin my-new-feature</li>
+                        <li>Submit a pull request =D</li>
+                    </ol>
+                </p>
+            </section>
 
-			<footer class="footer">
-				<section class="container">
-					<p>Designed with ♥ by <a target="blank" href="http://cjpatoilo.com" title="CJ Patoilo">CJ Patoilo</a>. Licensed under the <a target="blank" href="https://github.com/milligram/milligram#license" title="MIT License">MIT License</a>.</p>
-				</section>
-			</footer>
+            <footer class="footer">
+                <section class="container">
+                    <p>Designed with ♥ by <a target="blank" href="http://cjpatoilo.com" title="CJ Patoilo">CJ Patoilo</a>. Licensed under the <a target="blank" href="https://github.com/milligram/milligram#license" title="MIT License">MIT License</a>.</p>
+                </section>
+            </footer>
 
-		</main>
+        </main>
 
-		<script src="http://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
-		<script src="js/script.js"></script>
-
-	</body>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
+        <script src="js/script.js"></script>
+    </body>
 </html>

--- a/tips.html
+++ b/tips.html
@@ -7,32 +7,32 @@
 		<meta name="apple-mobile-web-app-status-bar-style" content="#f4f5f6">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<meta name="author" content="http://milligram.github.io/">
+		<meta name="author" content="https://milligram.github.io/">
 		<meta name="description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
 		<meta property="og:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta property="og:image" content="http://milligram.github.io/img/thumbnail.jpg">
+		<meta property="og:image" content="https://milligram.github.io/img/thumbnail.jpg">
 		<meta property="og:locale" content="en">
 		<meta property="og:site_name" content="Milligram | A minimalist CSS framework.">
 		<meta property="og:title" content="Milligram | A minimalist CSS framework.">
 		<meta property="og:type" content="website">
-		<meta property="og:url" content="http://milligram.github.io/">
+		<meta property="og:url" content="https://milligram.github.io/">
 		<meta property="article:published_time" content="2015-12-25T01:00:00Z">
 		<meta property="article:author" content="CJ Patoilo">
 		<meta property="article:section" content="website">
 		<meta name="twitter:card" content="summary_large_image">
 		<meta name="twitter:domain" content="Milligram | A minimalist CSS framework.">
-		<meta name="twitter:url" content="http://milligram.github.io/">
-		<meta name="twitter:site" content="http://milligram.github.io/">
+		<meta name="twitter:url" content="https://milligram.github.io/">
+		<meta name="twitter:site" content="https://milligram.github.io/">
 		<meta name="twitter:creator" content="CJ Patoilo">
 		<meta name="twitter:title" content="Milligram | A minimalist CSS framework.">
 		<meta name="twitter:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta name="twitter:image:src" content="http://milligram.github.io/img/thumbnail.jpg">
+		<meta name="twitter:image:src" content="https://milligram.github.io/img/thumbnail.jpg">
 		<title>Milligram | A minimalist CSS framework.</title>
-		<link rel="canonical" href="http://milligram.github.io/">
-		<link rel="image_src" href="http://milligram.github.io/img/thumbnail.jpg">
-		<link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
+		<link rel="canonical" href="https://milligram.github.io/">
+		<link rel="image_src" href="https://milligram.github.io/img/thumbnail.jpg">
+		<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
 		<link rel="stylesheet" href="css/milligram.min.css">
 		<link rel="stylesheet" href="css/style.css">
 		<link rel="icon" href="img/favicon.png">
@@ -216,7 +216,7 @@
 
 		</main>
 
-		<script src="http://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
 		<script src="js/script.js"></script>
 
 	</body>

--- a/typography.html
+++ b/typography.html
@@ -7,32 +7,32 @@
 		<meta name="apple-mobile-web-app-status-bar-style" content="#f4f5f6">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<meta name="author" content="http://milligram.github.io/">
+		<meta name="author" content="https://milligram.github.io/">
 		<meta name="description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
 		<meta property="og:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta property="og:image" content="http://milligram.github.io/img/thumbnail.jpg">
+		<meta property="og:image" content="https://milligram.github.io/img/thumbnail.jpg">
 		<meta property="og:locale" content="en">
 		<meta property="og:site_name" content="Milligram | A minimalist CSS framework.">
 		<meta property="og:title" content="Milligram | A minimalist CSS framework.">
 		<meta property="og:type" content="website">
-		<meta property="og:url" content="http://milligram.github.io/">
+		<meta property="og:url" content="https://milligram.github.io/">
 		<meta property="article:published_time" content="2015-12-25T01:00:00Z">
 		<meta property="article:author" content="CJ Patoilo">
 		<meta property="article:section" content="website">
 		<meta name="twitter:card" content="summary_large_image">
 		<meta name="twitter:domain" content="Milligram | A minimalist CSS framework.">
-		<meta name="twitter:url" content="http://milligram.github.io/">
-		<meta name="twitter:site" content="http://milligram.github.io/">
+		<meta name="twitter:url" content="https://milligram.github.io/">
+		<meta name="twitter:site" content="https://milligram.github.io/">
 		<meta name="twitter:creator" content="CJ Patoilo">
 		<meta name="twitter:title" content="Milligram | A minimalist CSS framework.">
 		<meta name="twitter:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta name="twitter:image:src" content="http://milligram.github.io/img/thumbnail.jpg">
+		<meta name="twitter:image:src" content="https://milligram.github.io/img/thumbnail.jpg">
 		<title>Milligram | A minimalist CSS framework.</title>
-		<link rel="canonical" href="http://milligram.github.io/">
-		<link rel="image_src" href="http://milligram.github.io/img/thumbnail.jpg">
-		<link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
+		<link rel="canonical" href="https://milligram.github.io/">
+		<link rel="image_src" href="https://milligram.github.io/img/thumbnail.jpg">
+		<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
 		<link rel="stylesheet" href="css/milligram.min.css">
 		<link rel="stylesheet" href="css/style.css">
 		<link rel="icon" href="img/favicon.png">
@@ -173,7 +173,7 @@
 
 		</main>
 
-		<script src="http://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
 		<script src="js/script.js"></script>
 
 	</body>

--- a/utilities.html
+++ b/utilities.html
@@ -7,32 +7,32 @@
 		<meta name="apple-mobile-web-app-status-bar-style" content="#f4f5f6">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<meta name="author" content="http://milligram.github.io/">
+		<meta name="author" content="https://milligram.github.io/">
 		<meta name="description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
 		<meta property="og:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta property="og:image" content="http://milligram.github.io/img/thumbnail.jpg">
+		<meta property="og:image" content="https://milligram.github.io/img/thumbnail.jpg">
 		<meta property="og:locale" content="en">
 		<meta property="og:site_name" content="Milligram | A minimalist CSS framework.">
 		<meta property="og:title" content="Milligram | A minimalist CSS framework.">
 		<meta property="og:type" content="website">
-		<meta property="og:url" content="http://milligram.github.io/">
+		<meta property="og:url" content="https://milligram.github.io/">
 		<meta property="article:published_time" content="2015-12-25T01:00:00Z">
 		<meta property="article:author" content="CJ Patoilo">
 		<meta property="article:section" content="website">
 		<meta name="twitter:card" content="summary_large_image">
 		<meta name="twitter:domain" content="Milligram | A minimalist CSS framework.">
-		<meta name="twitter:url" content="http://milligram.github.io/">
-		<meta name="twitter:site" content="http://milligram.github.io/">
+		<meta name="twitter:url" content="https://milligram.github.io/">
+		<meta name="twitter:site" content="https://milligram.github.io/">
 		<meta name="twitter:creator" content="CJ Patoilo">
 		<meta name="twitter:title" content="Milligram | A minimalist CSS framework.">
 		<meta name="twitter:description" content="Milligram provides a minimal setup of styles for a fast and clean starting point. Specially designed for better performance and higher productivity with fewer properties to reset resulting in cleaner code.">
-		<meta name="twitter:image:src" content="http://milligram.github.io/img/thumbnail.jpg">
+		<meta name="twitter:image:src" content="https://milligram.github.io/img/thumbnail.jpg">
 		<title>Milligram | A minimalist CSS framework.</title>
-		<link rel="canonical" href="http://milligram.github.io/">
-		<link rel="image_src" href="http://milligram.github.io/img/thumbnail.jpg">
-		<link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
+		<link rel="canonical" href="https://milligram.github.io/">
+		<link rel="image_src" href="https://milligram.github.io/img/thumbnail.jpg">
+		<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css">
 		<link rel="stylesheet" href="css/milligram.min.css">
 		<link rel="stylesheet" href="css/style.css">
 		<link rel="icon" href="img/favicon.png">
@@ -152,7 +152,7 @@
 
 		</main>
 
-		<script src="http://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.js"></script>
 		<script src="js/script.js"></script>
 
 	</body>


### PR DESCRIPTION
I noticed you were getting mixed content warnings so I decided to replace all valid http -> https links which includes google's fonts, all cdnjs links and github.io links as they all support https.