### PR TITLE
Use rawgit URL instead of raw.githubusercontent

### DIFF
--- a/src/scripts/version.js
+++ b/src/scripts/version.js
@@ -16,7 +16,7 @@
 
 	if (!$description || !$download) return
 
-	request.open('GET', `//raw.githubusercontent.com/${repository}/master/package.json`, true)
+	request.open('GET', `//cdn.rawgit.com/${repository}/master/package.json`, true)
 	request.onload = onload
 	request.send()
 })()


### PR DESCRIPTION
<!--

Contributing
==============================
We would love for you to contribute to Milligram and help us make this even better! Start reading this [document](https://github.com/milligram/milligram.github.io#contributing) to see it is not difficult as you might have imagined.

Code of Conduct
==============================
Help us keep Milligram open and inclusive. Please read and follow our thoughts on [Code of Conduct](http://confcodeofconduct.com/).

License
==============================
By contributing your code, you agree to license your contribution under the [MIT license](https://github.com/milligram/milligram.github.io#license).

-->

### Checklist
- [x] `npm start` and/or `npm test` it worked
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

Bug fixes and new features should include tests and possibly benchmarks.

### Description of change

raw.githubusercontent does not have CORS enable. On Firefox, it doesn't load this file (`Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at http://raw.githubusercontent.com/milligram/milligram/master/package.json. (Reason: CORS header ‘Access-Control-Allow-Origin’ missing)`).

As a workaround, I use rawgit that have enable CORS.

Thanks
