### PR TITLE
Remove '$' from terminal command examples

### DIFF
--- a/src/templates/getting-started.pug
+++ b/src/templates/getting-started.pug
@@ -14,21 +14,21 @@ section.container#getting-started
 			| Milligram is available to install using Bower.
 	pre.code.prettyprint
 		code.code-content
-			| $ bower install milligram
+			| bower install milligram
 	p
 		strong Install with npm
 	p
 		| Milligram is also available to install using npm.
 	pre.code.prettyprint
 		code.code-content
-			| $ npm install milligram
+			| npm install milligram
 	p
 		strong Install with Yarn
 	p
 		| Milligram is also available to install using Yarn.
 	pre.code.prettyprint
 		code.code-content
-			| $ yarn add milligram
+			| yarn add milligram
 	p
 		strong What's included
 	p
@@ -67,7 +67,7 @@ section.container#getting-started
 		| A CLI for getting started with Milligram. It offers a super simple boilerplate project with Milligram.
 	pre.code.prettyprint
 		code.code-content
-			| $ npm install -g milligram-cli
+			| npm install -g milligram-cli
 	p
 		| Create a new app using the command
 		= ' '
@@ -80,9 +80,9 @@ section.container#getting-started
 		| .
 	pre.code.prettyprint
 		code.code-content
-			| $ milligram init new_app
-			| $ cd new_app
-			| $ npm start
+			| milligram init new_app
+			| cd new_app
+			| npm start
 	if (home)
 		p
 			| See more examples of


### PR DESCRIPTION
Copy and pasting examples is easier with the '$' in the content.