### PR TITLE
only use sentry if it's loaded (aka not blocked)

### DIFF
--- a/src/scripts/apm.js
+++ b/src/scripts/apm.js
@@ -14,5 +14,8 @@
 	const dsn = 'https://dae18034fa014d1eb5a5ac9d8f0659da@sentry.io/1518770'
 	const environment = getEnvironment(window.location.hostname)
 
-	Sentry.init({ dsn, environment })
+	if (typeof Sentry !== 'undefined') {
+		Sentry.init({ dsn, environment })
+	}
+	
 })()


### PR DESCRIPTION
some (my) adblockers block sentry. accessing the `Sentry` object then causes a ReferenceError and that crash leads to incomplete loading of styles.

<img width="507" alt="Bildschirmfoto 2019-08-03 um 16 40 07" src="https://user-images.githubusercontent.com/201135/62413972-484c3380-b616-11e9-874c-2b785f42c4a0.png">

<img width="347" alt="Bildschirmfoto 2019-08-03 um 17 38 41" src="https://user-images.githubusercontent.com/201135/62413975-4da97e00-b616-11e9-90ec-07f4afec99a7.png">

